### PR TITLE
OpenRC build: merge world

### DIFF
--- a/scripts/openrc.sh
+++ b/scripts/openrc.sh
@@ -6,4 +6,5 @@ chroot "${GB_ROOT}" /bin/bash -x -e <<-'EOF'
 eselect profile set "${GB_ESELECT_PROFILE}"
 emerge --noreplace app-admin/sysklogd
 ln -s /etc/init.d/sysklogd /etc/runlevels/default
+emerge -vDN @world
 EOF


### PR DESCRIPTION
`/scripts/systemd.sh` [contains](https://github.com/OndrejHome/gentoo-build/blob/b35557755f5f05e99fec0c26284b811406762045/scripts/systemd.sh#L33) `emerge -vDN @world`.

`/scripts/openrc.sh` [doesn't contain](https://github.com/OndrejHome/gentoo-build/blob/b35557755f5f05e99fec0c26284b811406762045/scripts/openrc.sh).

@OndrejHome , is it correct? Thanks!